### PR TITLE
Add debt limits (like Nerite protocol)

### DIFF
--- a/contracts/src/AddressesRegistry.sol
+++ b/contracts/src/AddressesRegistry.sol
@@ -40,8 +40,11 @@ contract AddressesRegistry is Ownable, IAddressesRegistry {
     uint256 public immutable LIQUIDATION_PENALTY_SP;
     // Liquidation penalty for troves redistributed
     uint256 public immutable LIQUIDATION_PENALTY_REDISTRIBUTION;
+    // Initial debt limit for this collateral branch
+    uint256 public debtLimit;
 
     error InvalidCCR();
+    error InvalidDebtLimit();
     error InvalidMCR();
     error InvalidBCR();
     error InvalidSCR();
@@ -75,7 +78,8 @@ contract AddressesRegistry is Ownable, IAddressesRegistry {
         uint256 _bcr,
         uint256 _scr,
         uint256 _liquidationPenaltySP,
-        uint256 _liquidationPenaltyRedistribution
+        uint256 _liquidationPenaltyRedistribution,
+        uint256 _debtLimit
     ) Ownable(_owner) {
         if (_ccr <= 1e18 || _ccr >= 2e18) revert InvalidCCR();
         if (_mcr <= 1e18 || _mcr >= 2e18) revert InvalidMCR();
@@ -84,6 +88,7 @@ contract AddressesRegistry is Ownable, IAddressesRegistry {
         if (_liquidationPenaltySP < MIN_LIQUIDATION_PENALTY_SP) revert SPPenaltyTooLow();
         if (_liquidationPenaltySP > _liquidationPenaltyRedistribution) revert SPPenaltyGtRedist();
         if (_liquidationPenaltyRedistribution > MAX_LIQUIDATION_PENALTY_REDISTRIBUTION) revert RedistPenaltyTooHigh();
+        if (_debtLimit == 0) revert InvalidDebtLimit();
 
         CCR = _ccr;
         SCR = _scr;
@@ -91,6 +96,7 @@ contract AddressesRegistry is Ownable, IAddressesRegistry {
         BCR = _bcr;
         LIQUIDATION_PENALTY_SP = _liquidationPenaltySP;
         LIQUIDATION_PENALTY_REDISTRIBUTION = _liquidationPenaltyRedistribution;
+        debtLimit = _debtLimit;
     }
 
     function setAddresses(AddressVars memory _vars) external onlyOwner {

--- a/contracts/src/BorrowerOperations.sol
+++ b/contracts/src/BorrowerOperations.sol
@@ -360,6 +360,9 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
         vars.newTCR = _getNewTCRFromTroveChange(_change, vars.price);
         _requireNewTCRisAboveCCR(vars.newTCR);
 
+        // Check debt limit
+        _requireDebtLimitNotExceeded(vars.entireDebt);
+
         // --- Effects & interactions ---
 
         // Set add/remove managers
@@ -658,6 +661,11 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
 
         // Check the adjustment satisfies all conditions for the current system mode
         _requireValidAdjustmentInCurrentMode(_troveChange, vars, isTroveInBatch);
+
+        // Check debt limit if debt is increasing
+        if (_troveChange.debtIncrease > 0) {
+            _requireDebtLimitNotExceeded(_troveChange.debtIncrease + _troveChange.upfrontFee);
+        }
 
         // --- Effects and interactions ---
 
@@ -1612,5 +1620,14 @@ contract BorrowerOperations is LiquityBase, AddRemoveManagers, IBorrowerOperatio
         totalDebt -= _troveChange.debtDecrease;
 
         newTCR = LiquityMath._computeCR(totalColl, totalDebt, _price);
+    }
+
+    function _requireDebtLimitNotExceeded(uint256 _debtIncrease) internal view {
+        uint256 entireBranchDebt = getEntireBranchDebt();
+        uint256 debtLimit = troveManager.getDebtLimit();
+        require(
+            debtLimit >= entireBranchDebt + _debtIncrease,
+            "BorrowerOperations: Debt limit exceeded"
+        );
     }
 }

--- a/contracts/src/CollateralRegistry.sol
+++ b/contracts/src/CollateralRegistry.sol
@@ -44,10 +44,19 @@ contract CollateralRegistry is ICollateralRegistry {
     // The timestamp of the latest fee operation (redemption or new Bold issuance)
     uint256 public lastFeeOperationTime = block.timestamp;
 
+    // Governor address for updating debt limits
+    address public governor;
+
     event BaseRateUpdated(uint256 _baseRate);
     event LastFeeOpTimeUpdated(uint256 _lastFeeOpTime);
+    event DebtLimitUpdated(uint256 indexed _index, uint256 _oldLimit, uint256 _newLimit);
 
-    constructor(IBoldToken _boldToken, IERC20Metadata[] memory _tokens, ITroveManager[] memory _troveManagers) {
+    modifier onlyGovernor() {
+        require(msg.sender == governor, "CollateralRegistry: Only governor can call");
+        _;
+    }
+
+    constructor(IBoldToken _boldToken, IERC20Metadata[] memory _tokens, ITroveManager[] memory _troveManagers, address _governor) {
         uint256 numTokens = _tokens.length;
         require(numTokens > 0, "Collateral list cannot be empty");
         require(numTokens <= 10, "Collateral list too long");
@@ -80,6 +89,9 @@ contract CollateralRegistry is ICollateralRegistry {
         // Initialize the baseRate state variable
         baseRate = INITIAL_BASE_RATE;
         emit BaseRateUpdated(INITIAL_BASE_RATE);
+
+        // Set the governor
+        governor = _governor;
     }
 
     struct RedemptionTotals {
@@ -312,5 +324,28 @@ contract CollateralRegistry is ICollateralRegistry {
 
     function _requireAmountGreaterThanZero(uint256 _amount) internal pure {
         require(_amount > 0, "CollateralRegistry: Amount must be greater than zero");
+    }
+
+    // --- Debt Limit Functions ---
+
+    function updateDebtLimit(uint256 _indexTroveManager, uint256 _newDebtLimit) external onlyGovernor {
+        require(_indexTroveManager < totalCollaterals, "Invalid index");
+        uint256 currentDebtLimit = getTroveManager(_indexTroveManager).getDebtLimit();
+        
+        // If increasing, can only double or reset to initial
+        if (_newDebtLimit > currentDebtLimit) {
+            require(
+                _newDebtLimit <= currentDebtLimit * 2 || _newDebtLimit <= getTroveManager(_indexTroveManager).getInitialDebtLimit(),
+                "CollateralRegistry: Debt limit increase by more than 2x is not allowed"
+            );
+        }
+        
+        emit DebtLimitUpdated(_indexTroveManager, currentDebtLimit, _newDebtLimit);
+        getTroveManager(_indexTroveManager).setDebtLimit(_newDebtLimit);
+    }
+
+    function getDebtLimit(uint256 _indexTroveManager) external view returns (uint256) {
+        require(_indexTroveManager < totalCollaterals, "Invalid index");
+        return getTroveManager(_indexTroveManager).getDebtLimit();
     }
 }

--- a/contracts/src/Interfaces/IAddressesRegistry.sol
+++ b/contracts/src/Interfaces/IAddressesRegistry.sol
@@ -46,6 +46,7 @@ interface IAddressesRegistry {
     function BCR() external returns (uint256);
     function LIQUIDATION_PENALTY_SP() external returns (uint256);
     function LIQUIDATION_PENALTY_REDISTRIBUTION() external returns (uint256);
+    function debtLimit() external returns (uint256);
 
     function collToken() external view returns (IERC20Metadata);
     function borrowerOperations() external view returns (IBorrowerOperations);

--- a/contracts/src/Interfaces/ICollateralRegistry.sol
+++ b/contracts/src/Interfaces/ICollateralRegistry.sol
@@ -23,4 +23,8 @@ interface ICollateralRegistry {
 
     function getRedemptionFeeWithDecay(uint256 _ETHDrawn) external view returns (uint256);
     function getEffectiveRedemptionFeeInBold(uint256 _redeemAmount) external view returns (uint256);
+
+    // Debt limit functions
+    function updateDebtLimit(uint256 _indexTroveManager, uint256 _newDebtLimit) external;
+    function getDebtLimit(uint256 _indexTroveManager) external view returns (uint256);
 }

--- a/contracts/src/Interfaces/ITroveManager.sol
+++ b/contracts/src/Interfaces/ITroveManager.sol
@@ -171,4 +171,9 @@ interface ITroveManager is ILiquityBase {
     ) external;
 
     // -- end of permissioned functions --
+
+    // Debt limit functions
+    function setDebtLimit(uint256 _newDebtLimit) external;
+    function getDebtLimit() external view returns (uint256);
+    function getInitialDebtLimit() external view returns (uint256);
 }

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -43,6 +43,11 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
     // Liquidation penalty for troves redistributed
     uint256 internal immutable LIQUIDATION_PENALTY_REDISTRIBUTION;
 
+    // Debt limit for this collateral branch
+    uint256 public debtLimit;
+    // Initial debt limit (for governance doubling restrictions)
+    uint256 public initialDebtLimit;
+
     // --- Data structures ---
 
     // Store the necessary data for a trove
@@ -192,6 +197,8 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         SCR = _addressesRegistry.SCR();
         LIQUIDATION_PENALTY_SP = _addressesRegistry.LIQUIDATION_PENALTY_SP();
         LIQUIDATION_PENALTY_REDISTRIBUTION = _addressesRegistry.LIQUIDATION_PENALTY_REDISTRIBUTION();
+        debtLimit = _addressesRegistry.debtLimit();
+        initialDebtLimit = debtLimit;
 
         troveNFT = _addressesRegistry.troveNFT();
         borrowerOperations = _addressesRegistry.borrowerOperations();
@@ -2002,5 +2009,20 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
 
         Troves[_troveId].interestBatchManager = address(0);
         Troves[_troveId].batchDebtShares = 0;
+    }
+
+    // --- Debt Limit Functions ---
+
+    function getDebtLimit() external view override returns (uint256) {
+        return debtLimit;
+    }
+
+    function getInitialDebtLimit() external view override returns (uint256) {
+        return initialDebtLimit;
+    }
+
+    function setDebtLimit(uint256 _newDebtLimit) external override {
+        _requireCallerIsCollateralRegistry();
+        debtLimit = _newDebtLimit;
     }
 }

--- a/contracts/test/SortedTroves.t.sol
+++ b/contracts/test/SortedTroves.t.sol
@@ -470,7 +470,7 @@ contract SortedTrovesTest is Test {
     function setUp() public {
         bytes32 SALT = keccak256("LiquityV2");
         AddressesRegistry addressesRegistry =
-            new AddressesRegistry(address(this), 150e16, 110e16, 10e16, 110e16, 5e16, 10e16);
+            new AddressesRegistry(address(this), 150e16, 110e16, 10e16, 110e16, 5e16, 10e16, 1e27);
         bytes32 hash = keccak256(
             abi.encodePacked(
                 bytes1(0xff),

--- a/contracts/test/TestContracts/CollateralRegistryTester.sol
+++ b/contracts/test/TestContracts/CollateralRegistryTester.sol
@@ -8,8 +8,8 @@ import "src/CollateralRegistry.sol";
 for testing the parent's internal functions. */
 
 contract CollateralRegistryTester is CollateralRegistry {
-    constructor(IBoldToken _boldToken, IERC20Metadata[] memory _tokens, ITroveManager[] memory _troveManagers)
-        CollateralRegistry(_boldToken, _tokens, _troveManagers)
+    constructor(IBoldToken _boldToken, IERC20Metadata[] memory _tokens, ITroveManager[] memory _troveManagers, address _governor)
+        CollateralRegistry(_boldToken, _tokens, _troveManagers, _governor)
     {}
 
     function unprotectedDecayBaseRateFromBorrowing() external returns (uint256) {

--- a/contracts/test/TestContracts/Deployment.t.sol
+++ b/contracts/test/TestContracts/Deployment.t.sol
@@ -139,6 +139,7 @@ contract TestDeployer is MetadataDeployment {
         uint256 SCR;
         uint256 LIQUIDATION_PENALTY_SP;
         uint256 LIQUIDATION_PENALTY_REDISTRIBUTION;
+        uint256 DEBT_LIMIT;
     }
 
     struct DeploymentVarsDev {
@@ -330,7 +331,7 @@ contract TestDeployer is MetadataDeployment {
             vars.troveManagers[vars.i] = ITroveManager(troveManagerAddress);
         }
 
-        collateralRegistry = new CollateralRegistry(boldToken, vars.collaterals, vars.troveManagers);
+        collateralRegistry = new CollateralRegistry(boldToken, vars.collaterals, vars.troveManagers, address(this));
         hintHelpers = new HintHelpers(collateralRegistry);
         multiTroveGetter = new MultiTroveGetter(collateralRegistry);
 
@@ -373,7 +374,8 @@ contract TestDeployer is MetadataDeployment {
             _troveManagerParams.BCR,
             _troveManagerParams.SCR,
             _troveManagerParams.LIQUIDATION_PENALTY_SP,
-            _troveManagerParams.LIQUIDATION_PENALTY_REDISTRIBUTION
+            _troveManagerParams.LIQUIDATION_PENALTY_REDISTRIBUTION,
+            _troveManagerParams.DEBT_LIMIT > 0 ? _troveManagerParams.DEBT_LIMIT : 1e27 // Default 1 billion BOLD
         );
         address troveManagerAddress = getAddress(
             address(this), getBytecode(type(TroveManagerTester).creationCode, address(addressesRegistry)), SALT
@@ -555,7 +557,7 @@ contract TestDeployer is MetadataDeployment {
         vars.troveManagers[2] = ITroveManager(troveManagerAddress);
 
         // Deploy registry and register the TMs
-        result.collateralRegistry = new CollateralRegistryTester(result.boldToken, vars.collaterals, vars.troveManagers);
+        result.collateralRegistry = new CollateralRegistryTester(result.boldToken, vars.collaterals, vars.troveManagers, address(this));
 
         result.hintHelpers = new HintHelpers(result.collateralRegistry);
         result.multiTroveGetter = new MultiTroveGetter(result.collateralRegistry);
@@ -593,7 +595,8 @@ contract TestDeployer is MetadataDeployment {
             _troveManagerParams.BCR,
             _troveManagerParams.SCR,
             _troveManagerParams.LIQUIDATION_PENALTY_SP,
-            _troveManagerParams.LIQUIDATION_PENALTY_REDISTRIBUTION
+            _troveManagerParams.LIQUIDATION_PENALTY_REDISTRIBUTION,
+            _troveManagerParams.DEBT_LIMIT > 0 ? _troveManagerParams.DEBT_LIMIT : 1e27 // Default 1 billion BOLD
         );
         address troveManagerAddress =
             getAddress(address(this), getBytecode(type(TroveManager).creationCode, address(addressesRegistry)), SALT);


### PR DESCRIPTION
## Overview

Adds debt limits per collateral branch, modeled after the Nerite protocol implementation.

## Core Changes

### AddressesRegistry
- Added `debtLimit` parameter to constructor
- Added `InvalidDebtLimit` error

### TroveManager
- Added `debtLimit` and `initialDebtLimit` state variables
- Added `getDebtLimit()`, `getInitialDebtLimit()`, `setDebtLimit()` functions

### BorrowerOperations
- Added debt limit check on `openTrove` and `adjustTrove` (when debt increases)
- New `_requireDebtLimitNotExceeded()` internal function

### CollateralRegistry
- Added `governor` address for permissioned debt limit updates
- Added `onlyGovernor` modifier
- Added `updateDebtLimit()` - can only increase by 2x or reset to initial
- Added `getDebtLimit()`
- Added `DebtLimitUpdated` event

### Interfaces Updated
- `ITroveManager`: added debt limit functions
- `IAddressesRegistry`: added `debtLimit()`
- `ICollateralRegistry`: added `updateDebtLimit()`, `getDebtLimit()`

## Test Updates (Partial)
- Updated `TroveManagerParams` struct to include `DEBT_LIMIT`
- Updated some test instantiations

## TODO (follow-up)
- [ ] Update remaining test files with new struct parameter (~32 places)
- [ ] Update `DeployLiquity2.s.sol` deployment script

## Reference
Based on Nerite implementation: https://github.com/NeriteOrg/nerite