### PR TITLE
Add price feeds for SNT, LINEA, and sGUSD

### DIFF
--- a/contracts/src/PriceFeeds/LINEAPriceFeed.sol
+++ b/contracts/src/PriceFeeds/LINEAPriceFeed.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "./MainnetPriceFeedBase.sol";
+
+/**
+ * @title LINEAPriceFeed
+ * @notice Price feed for LINEA token
+ * @dev Uses a single LINEA-USD oracle
+ */
+contract LINEAPriceFeed is MainnetPriceFeedBase {
+    // TODO: Set the actual LINEA-USD oracle address on deployment
+    // address constant LINEA_USD_ORACLE = address(0);
+
+    constructor(
+        address _lineaUsdOracleAddress,
+        uint256 _lineaUsdStalenessThreshold,
+        address _borrowerOperationsAddress
+    )
+        MainnetPriceFeedBase(_lineaUsdOracleAddress, _lineaUsdStalenessThreshold, _borrowerOperationsAddress)
+    {
+        _fetchPricePrimary();
+
+        // Check the oracle didn't already fail
+        assert(priceSource == PriceSource.primary);
+    }
+
+    function fetchPrice() public returns (uint256, bool) {
+        // If branch is live and the primary oracle setup has been working, try to use it
+        if (priceSource == PriceSource.primary) return _fetchPricePrimary();
+
+        // Otherwise if branch is shut down and already using the lastGoodPrice, continue with it
+        assert(priceSource == PriceSource.lastGoodPrice);
+        return (lastGoodPrice, false);
+    }
+
+    function fetchRedemptionPrice() external returns (uint256, bool) {
+        // Use same price for redemption as all other ops
+        return fetchPrice();
+    }
+
+    function _fetchPricePrimary() internal returns (uint256, bool) {
+        assert(priceSource == PriceSource.primary);
+        (uint256 lineaUsdPrice, bool lineaUsdOracleDown) = _getOracleAnswer(ethUsdOracle);
+
+        // If the LINEA-USD oracle response was invalid, return the last good price
+        if (lineaUsdOracleDown) return (_shutDownAndSwitchToLastGoodPrice(address(ethUsdOracle.aggregator)), true);
+
+        lastGoodPrice = lineaUsdPrice;
+        return (lineaUsdPrice, false);
+    }
+}

--- a/contracts/src/PriceFeeds/ORACLE_CONFIG.md
+++ b/contracts/src/PriceFeeds/ORACLE_CONFIG.md
@@ -1,0 +1,40 @@
+# Price Feed Oracle Configuration
+
+This document lists the oracle addresses needed for each price feed.
+All addresses need to be filled in before deployment.
+
+## Supported Collaterals
+
+| Token | Price Feed Contract | Oracle Type | Oracle Address | Staleness Threshold |
+|-------|-------------------|-------------|----------------|---------------------|
+| ETH | WETHPriceFeed | ETH-USD | `TODO: address(0)` | 25 hours |
+| wstETH | WSTETHPriceFeed | ETH-USD + STETH-USD + Exchange Rate | `TODO: address(0)` | 25 hours |
+| rETH | RETHPriceFeed | ETH-USD + RETH-ETH + Exchange Rate | `TODO: address(0)` | 25 hours |
+| SNT | SNTPriceFeed | SNT-USD | `TODO: address(0)` | 25 hours |
+| LINEA | LINEAPriceFeed | LINEA-USD | `TODO: address(0)` | 25 hours |
+| sGUSD | SGUSDPriceFeed | sGUSD-USD | `TODO: address(0)` | 25 hours |
+
+## Collateral Parameters (from spec)
+
+| Token | Initial Debt Limit | MCR | SCR | CCR | Liq Penalty |
+|-------|-------------------|-----|-----|-----|-------------|
+| ETH | $100,000,000 | 110% | 110% | 150% | 5% |
+| wstETH | $100,000,000 | 110% | 110% | 160% | 5% |
+| rETH | $100,000,000 | 110% | 110% | 160% | 5% |
+| SNT | $2,000,000 | 160% | 160% | 185% | 5% |
+| LINEA | $2,000,000 | TBD | TBD | TBD | 5% |
+| sGUSD | $5,000,000 | 110% | 110% | 125% | 5% |
+
+## Notes
+
+1. **Staleness threshold**: All feeds use 25 hours (90000 seconds) as the staleness threshold
+2. **SNT**: Status Network Token - may need a custom oracle or use Chainlink if available
+3. **LINEA**: Linea token - oracle TBD
+4. **sGUSD**: Staked GUSD - likely pegged close to $1, may use GUSD oracle
+
+## Deployment Steps
+
+1. Obtain oracle addresses for each token
+2. Update the deployment script with the addresses
+3. Deploy price feeds with correct staleness thresholds
+4. Verify all oracles are returning valid prices before deployment

--- a/contracts/src/PriceFeeds/SGUSDPriceFeed.sol
+++ b/contracts/src/PriceFeeds/SGUSDPriceFeed.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "./MainnetPriceFeedBase.sol";
+
+/**
+ * @title SGUSDPriceFeed
+ * @notice Price feed for sGUSD (staked GUSD)
+ * @dev Uses a single sGUSD-USD oracle. sGUSD is expected to track $1 closely.
+ */
+contract SGUSDPriceFeed is MainnetPriceFeedBase {
+    // TODO: Set the actual sGUSD-USD oracle address on deployment
+    // address constant SGUSD_USD_ORACLE = address(0);
+    
+    // sGUSD is a stablecoin, expected to be ~$1
+    // May use a fixed price or GUSD oracle as fallback
+
+    constructor(
+        address _sgusdUsdOracleAddress,
+        uint256 _sgusdUsdStalenessThreshold,
+        address _borrowerOperationsAddress
+    )
+        MainnetPriceFeedBase(_sgusdUsdOracleAddress, _sgusdUsdStalenessThreshold, _borrowerOperationsAddress)
+    {
+        _fetchPricePrimary();
+
+        // Check the oracle didn't already fail
+        assert(priceSource == PriceSource.primary);
+    }
+
+    function fetchPrice() public returns (uint256, bool) {
+        // If branch is live and the primary oracle setup has been working, try to use it
+        if (priceSource == PriceSource.primary) return _fetchPricePrimary();
+
+        // Otherwise if branch is shut down and already using the lastGoodPrice, continue with it
+        assert(priceSource == PriceSource.lastGoodPrice);
+        return (lastGoodPrice, false);
+    }
+
+    function fetchRedemptionPrice() external returns (uint256, bool) {
+        // Use same price for redemption as all other ops
+        return fetchPrice();
+    }
+
+    function _fetchPricePrimary() internal returns (uint256, bool) {
+        assert(priceSource == PriceSource.primary);
+        (uint256 sgusdUsdPrice, bool sgusdUsdOracleDown) = _getOracleAnswer(ethUsdOracle);
+
+        // If the sGUSD-USD oracle response was invalid, return the last good price
+        if (sgusdUsdOracleDown) return (_shutDownAndSwitchToLastGoodPrice(address(ethUsdOracle.aggregator)), true);
+
+        lastGoodPrice = sgusdUsdPrice;
+        return (sgusdUsdPrice, false);
+    }
+}

--- a/contracts/src/PriceFeeds/SNTPriceFeed.sol
+++ b/contracts/src/PriceFeeds/SNTPriceFeed.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "./MainnetPriceFeedBase.sol";
+
+/**
+ * @title SNTPriceFeed
+ * @notice Price feed for Status Network Token (SNT)
+ * @dev Uses a single SNT-USD oracle
+ */
+contract SNTPriceFeed is MainnetPriceFeedBase {
+    // TODO: Set the actual SNT-USD oracle address on deployment
+    // address constant SNT_USD_ORACLE = address(0);
+
+    constructor(
+        address _sntUsdOracleAddress,
+        uint256 _sntUsdStalenessThreshold,
+        address _borrowerOperationsAddress
+    )
+        MainnetPriceFeedBase(_sntUsdOracleAddress, _sntUsdStalenessThreshold, _borrowerOperationsAddress)
+    {
+        _fetchPricePrimary();
+
+        // Check the oracle didn't already fail
+        assert(priceSource == PriceSource.primary);
+    }
+
+    function fetchPrice() public returns (uint256, bool) {
+        // If branch is live and the primary oracle setup has been working, try to use it
+        if (priceSource == PriceSource.primary) return _fetchPricePrimary();
+
+        // Otherwise if branch is shut down and already using the lastGoodPrice, continue with it
+        assert(priceSource == PriceSource.lastGoodPrice);
+        return (lastGoodPrice, false);
+    }
+
+    function fetchRedemptionPrice() external returns (uint256, bool) {
+        // Use same price for redemption as all other ops
+        return fetchPrice();
+    }
+
+    function _fetchPricePrimary() internal returns (uint256, bool) {
+        assert(priceSource == PriceSource.primary);
+        (uint256 sntUsdPrice, bool sntUsdOracleDown) = _getOracleAnswer(ethUsdOracle);
+
+        // If the SNT-USD oracle response was invalid, return the last good price
+        if (sntUsdOracleDown) return (_shutDownAndSwitchToLastGoodPrice(address(ethUsdOracle.aggregator)), true);
+
+        lastGoodPrice = sntUsdPrice;
+        return (sntUsdPrice, false);
+    }
+}


### PR DESCRIPTION
## Overview

Adds price feed contracts for the new collateral types. Oracle addresses use `address(0)` placeholders with TODOs.

## New Price Feeds

| Token | Contract | Description |
|-------|----------|-------------|
| SNT | `SNTPriceFeed.sol` | Status Network Token |
| LINEA | `LINEAPriceFeed.sol` | LINEA token |
| sGUSD | `SGUSDPriceFeed.sol` | Staked GUSD |

All extend `MainnetPriceFeedBase` with simple single-oracle pattern (like WETHPriceFeed).

## Existing Price Feeds (unchanged)

- `WETHPriceFeed` - ETH
- `WSTETHPriceFeed` - wstETH  
- `RETHPriceFeed` - rETH

## Documentation

Added `ORACLE_CONFIG.md` documenting:
- Required oracle addresses (all `TODO: address(0)`)
- Collateral parameters from spec (MCR, SCR, CCR, debt limits)
- Staleness thresholds (25 hours for all)

## Collaterals Supported (6 total)

1. ETH - $100M debt limit, 110/110/150 ratios
2. wstETH - $100M debt limit, 110/110/160 ratios
3. rETH - $100M debt limit, 110/110/160 ratios
4. SNT - $2M debt limit, 160/160/185 ratios
5. LINEA - $2M debt limit, ratios TBD
6. sGUSD - $5M debt limit, 110/110/125 ratios

## TODO

- [ ] Fill in oracle addresses before deployment
- [ ] Verify oracles are live and returning valid data