### PR TITLE
Update deployment script for 6 collaterals

### DIFF
--- a/contracts/script/DeployLiquity2.s.sol
+++ b/contracts/script/DeployLiquity2.s.sol
@@ -9,7 +9,22 @@ import {IERC20 as IERC20_GOV} from "openzeppelin/contracts/token/ERC20/IERC20.so
 import {StringFormatting} from "test/Utils/StringFormatting.sol";
 import {Accounts} from "test/TestContracts/Accounts.sol";
 import {ERC20Faucet} from "test/TestContracts/ERC20Faucet.sol";
-import {ETH_GAS_COMPENSATION} from "src/Dependencies/Constants.sol";
+import {
+    ETH_GAS_COMPENSATION,
+    BCR_ALL,
+    CCR_WETH, MCR_WETH, SCR_WETH,
+    CCR_SETH, MCR_SETH, SCR_SETH,
+    CCR_SNT, MCR_SNT, SCR_SNT,
+    CCR_LINEA, MCR_LINEA, SCR_LINEA,
+    CCR_SGUSD, MCR_SGUSD, SCR_SGUSD,
+    LIQUIDATION_PENALTY_SP_WETH, LIQUIDATION_PENALTY_REDISTRIBUTION_WETH,
+    LIQUIDATION_PENALTY_SP_SETH, LIQUIDATION_PENALTY_REDISTRIBUTION_SETH,
+    LIQUIDATION_PENALTY_SP_SNT, LIQUIDATION_PENALTY_REDISTRIBUTION_SNT,
+    LIQUIDATION_PENALTY_SP_LINEA, LIQUIDATION_PENALTY_REDISTRIBUTION_LINEA,
+    LIQUIDATION_PENALTY_SP_SGUSD, LIQUIDATION_PENALTY_REDISTRIBUTION_SGUSD,
+    DEBT_LIMIT_ETH, DEBT_LIMIT_WSTETH, DEBT_LIMIT_RETH,
+    DEBT_LIMIT_SNT, DEBT_LIMIT_LINEA, DEBT_LIMIT_SGUSD
+} from "src/Dependencies/Constants.sol";
 import {IBorrowerOperations} from "src/Interfaces/IBorrowerOperations.sol";
 import "src/AddressesRegistry.sol";
 import "src/ActivePool.sol";
@@ -29,6 +44,9 @@ import "src/StabilityPool.sol";
 import "src/PriceFeeds/WETHPriceFeed.sol";
 import "src/PriceFeeds/WSTETHPriceFeed.sol";
 import "src/PriceFeeds/RETHPriceFeed.sol";
+import "src/PriceFeeds/SNTPriceFeed.sol";
+import "src/PriceFeeds/LINEAPriceFeed.sol";
+import "src/PriceFeeds/SGUSDPriceFeed.sol";
 import "src/CollateralRegistry.sol";
 import "test/TestContracts/PriceFeedTestnet.sol";
 import "test/TestContracts/MetadataDeployment.sol";
@@ -70,7 +88,7 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
     string constant DEPLOYMENT_MODE_BOLD_ONLY = "bold-only";
     string constant DEPLOYMENT_MODE_USE_EXISTING_BOLD = "use-existing-bold";
 
-    uint256 constant NUM_BRANCHES = 3;
+    uint256 constant NUM_BRANCHES = 6; // ETH, wstETH, rETH, SNT, LINEA, sGUSD
 
     address WETH_ADDRESS = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address USDC_ADDRESS = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
@@ -81,12 +99,27 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
     IERC20Metadata USDC;
     address WSTETH_ADDRESS = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
     address RETH_ADDRESS = 0xae78736Cd615f374D3085123A210448E74Fc6393;
+    // TODO: Fill in actual token addresses for new collaterals
+    address SNT_ADDRESS = address(0); // Status Network Token
+    address LINEA_ADDRESS = address(0); // LINEA token
+    address SGUSD_ADDRESS = address(0); // sGUSD token
+    
+    // Oracle addresses
     address ETH_ORACLE_ADDRESS = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
     address RETH_ORACLE_ADDRESS = 0x536218f9E9Eb48863970252233c8F271f554C2d0;
     address STETH_ORACLE_ADDRESS = 0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8;
-    uint256 ETH_USD_STALENESS_THRESHOLD = 24 hours;
-    uint256 STETH_USD_STALENESS_THRESHOLD = 24 hours;
+    // TODO: Fill in oracle addresses for new collaterals
+    address SNT_ORACLE_ADDRESS = address(0);
+    address LINEA_ORACLE_ADDRESS = address(0);
+    address SGUSD_ORACLE_ADDRESS = address(0);
+    
+    // Staleness thresholds
+    uint256 ETH_USD_STALENESS_THRESHOLD = 25 hours; // Updated to 25h per spec
+    uint256 STETH_USD_STALENESS_THRESHOLD = 25 hours;
     uint256 RETH_ETH_STALENESS_THRESHOLD = 48 hours;
+    uint256 SNT_USD_STALENESS_THRESHOLD = 25 hours;
+    uint256 LINEA_USD_STALENESS_THRESHOLD = 25 hours;
+    uint256 SGUSD_USD_STALENESS_THRESHOLD = 25 hours;
 
     // V1
     address LQTY_ADDRESS = 0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D;
@@ -353,12 +386,48 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
         // rETH (same as wstETH)
         troveManagerParamsArray[2] = troveManagerParamsArray[1];
 
-        string[] memory collNames = new string[](2);
-        string[] memory collSymbols = new string[](2);
+        // SNT (Status Network Token)
+        troveManagerParamsArray[3] = TroveManagerParams({
+            CCR: CCR_SNT,
+            MCR: MCR_SNT,
+            SCR: SCR_SNT,
+            BCR: BCR_ALL,
+            LIQUIDATION_PENALTY_SP: LIQUIDATION_PENALTY_SP_SNT,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: LIQUIDATION_PENALTY_REDISTRIBUTION_SNT
+        });
+
+        // LINEA
+        troveManagerParamsArray[4] = TroveManagerParams({
+            CCR: CCR_LINEA,
+            MCR: MCR_LINEA,
+            SCR: SCR_LINEA,
+            BCR: BCR_ALL,
+            LIQUIDATION_PENALTY_SP: LIQUIDATION_PENALTY_SP_LINEA,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: LIQUIDATION_PENALTY_REDISTRIBUTION_LINEA
+        });
+
+        // sGUSD (staked GUSD - stablecoin)
+        troveManagerParamsArray[5] = TroveManagerParams({
+            CCR: CCR_SGUSD,
+            MCR: MCR_SGUSD,
+            SCR: SCR_SGUSD,
+            BCR: BCR_ALL,
+            LIQUIDATION_PENALTY_SP: LIQUIDATION_PENALTY_SP_SGUSD,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: LIQUIDATION_PENALTY_REDISTRIBUTION_SGUSD
+        });
+
+        string[] memory collNames = new string[](5); // All except WETH (index 0)
+        string[] memory collSymbols = new string[](5);
         collNames[0] = "Wrapped liquid staked Ether 2.0";
         collSymbols[0] = "wstETH";
         collNames[1] = "Rocket Pool ETH";
         collSymbols[1] = "rETH";
+        collNames[2] = "Status Network Token";
+        collSymbols[2] = "SNT";
+        collNames[3] = "LINEA";
+        collSymbols[3] = "LINEA";
+        collNames[4] = "Staked GUSD";
+        collSymbols[4] = "sGUSD";
 
         DeployGovernanceParams memory deployGovernanceParams = DeployGovernanceParams({
             epochStart: epochStart,

--- a/contracts/src/Dependencies/Constants.sol
+++ b/contracts/src/Dependencies/Constants.sol
@@ -21,10 +21,25 @@ uint256 constant CCR_WETH = 150 * _1pct;
 uint256 constant CCR_SETH = 160 * _1pct;
 
 uint256 constant MCR_WETH = 110 * _1pct;
-uint256 constant MCR_SETH = 120 * _1pct;
+uint256 constant MCR_SETH = 110 * _1pct; // Updated: was 120%, now 110% per spec
 
 uint256 constant SCR_WETH = 110 * _1pct;
-uint256 constant SCR_SETH = 120 * _1pct;
+uint256 constant SCR_SETH = 110 * _1pct; // Updated: was 120%, now 110% per spec
+
+// SNT (Status Network Token) parameters
+uint256 constant CCR_SNT = 185 * _1pct;
+uint256 constant MCR_SNT = 160 * _1pct;
+uint256 constant SCR_SNT = 160 * _1pct;
+
+// LINEA token parameters (using conservative defaults)
+uint256 constant CCR_LINEA = 185 * _1pct;
+uint256 constant MCR_LINEA = 160 * _1pct;
+uint256 constant SCR_LINEA = 160 * _1pct;
+
+// sGUSD (staked GUSD) parameters - stablecoin, tighter ratios
+uint256 constant CCR_SGUSD = 125 * _1pct;
+uint256 constant MCR_SGUSD = 110 * _1pct;
+uint256 constant SCR_SGUSD = 110 * _1pct;
 
 // Batch CR buffer (same for all branches for now)
 // On top of MCR to join a batch, or adjust inside a batch
@@ -32,9 +47,23 @@ uint256 constant BCR_ALL = 10 * _1pct;
 
 uint256 constant LIQUIDATION_PENALTY_SP_WETH = 5 * _1pct;
 uint256 constant LIQUIDATION_PENALTY_SP_SETH = 5 * _1pct;
+uint256 constant LIQUIDATION_PENALTY_SP_SNT = 5 * _1pct;
+uint256 constant LIQUIDATION_PENALTY_SP_LINEA = 5 * _1pct;
+uint256 constant LIQUIDATION_PENALTY_SP_SGUSD = 5 * _1pct;
 
 uint256 constant LIQUIDATION_PENALTY_REDISTRIBUTION_WETH = 10 * _1pct;
 uint256 constant LIQUIDATION_PENALTY_REDISTRIBUTION_SETH = 20 * _1pct;
+uint256 constant LIQUIDATION_PENALTY_REDISTRIBUTION_SNT = 10 * _1pct;
+uint256 constant LIQUIDATION_PENALTY_REDISTRIBUTION_LINEA = 10 * _1pct;
+uint256 constant LIQUIDATION_PENALTY_REDISTRIBUTION_SGUSD = 10 * _1pct;
+
+// Debt limits (in BOLD, 18 decimals)
+uint256 constant DEBT_LIMIT_ETH = 100_000_000e18; // $100M
+uint256 constant DEBT_LIMIT_WSTETH = 100_000_000e18; // $100M
+uint256 constant DEBT_LIMIT_RETH = 100_000_000e18; // $100M
+uint256 constant DEBT_LIMIT_SNT = 2_000_000e18; // $2M
+uint256 constant DEBT_LIMIT_LINEA = 2_000_000e18; // $2M
+uint256 constant DEBT_LIMIT_SGUSD = 5_000_000e18; // $5M
 
 // Fraction of collateral awarded to liquidator
 uint256 constant COLL_GAS_COMPENSATION_DIVISOR = 200; // dividing by 200 yields 0.5%

--- a/contracts/src/PriceFeeds/LINEAPriceFeed.sol
+++ b/contracts/src/PriceFeeds/LINEAPriceFeed.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "./MainnetPriceFeedBase.sol";
+
+/**
+ * @title LINEAPriceFeed
+ * @notice Price feed for LINEA token
+ * @dev Uses a single LINEA-USD oracle
+ */
+contract LINEAPriceFeed is MainnetPriceFeedBase {
+    // TODO: Set the actual LINEA-USD oracle address on deployment
+    // address constant LINEA_USD_ORACLE = address(0);
+
+    constructor(
+        address _lineaUsdOracleAddress,
+        uint256 _lineaUsdStalenessThreshold,
+        address _borrowerOperationsAddress
+    )
+        MainnetPriceFeedBase(_lineaUsdOracleAddress, _lineaUsdStalenessThreshold, _borrowerOperationsAddress)
+    {
+        _fetchPricePrimary();
+
+        // Check the oracle didn't already fail
+        assert(priceSource == PriceSource.primary);
+    }
+
+    function fetchPrice() public returns (uint256, bool) {
+        // If branch is live and the primary oracle setup has been working, try to use it
+        if (priceSource == PriceSource.primary) return _fetchPricePrimary();
+
+        // Otherwise if branch is shut down and already using the lastGoodPrice, continue with it
+        assert(priceSource == PriceSource.lastGoodPrice);
+        return (lastGoodPrice, false);
+    }
+
+    function fetchRedemptionPrice() external returns (uint256, bool) {
+        // Use same price for redemption as all other ops
+        return fetchPrice();
+    }
+
+    function _fetchPricePrimary() internal returns (uint256, bool) {
+        assert(priceSource == PriceSource.primary);
+        (uint256 lineaUsdPrice, bool lineaUsdOracleDown) = _getOracleAnswer(ethUsdOracle);
+
+        // If the LINEA-USD oracle response was invalid, return the last good price
+        if (lineaUsdOracleDown) return (_shutDownAndSwitchToLastGoodPrice(address(ethUsdOracle.aggregator)), true);
+
+        lastGoodPrice = lineaUsdPrice;
+        return (lineaUsdPrice, false);
+    }
+}

--- a/contracts/src/PriceFeeds/ORACLE_CONFIG.md
+++ b/contracts/src/PriceFeeds/ORACLE_CONFIG.md
@@ -1,0 +1,40 @@
+# Price Feed Oracle Configuration
+
+This document lists the oracle addresses needed for each price feed.
+All addresses need to be filled in before deployment.
+
+## Supported Collaterals
+
+| Token | Price Feed Contract | Oracle Type | Oracle Address | Staleness Threshold |
+|-------|-------------------|-------------|----------------|---------------------|
+| ETH | WETHPriceFeed | ETH-USD | `TODO: address(0)` | 25 hours |
+| wstETH | WSTETHPriceFeed | ETH-USD + STETH-USD + Exchange Rate | `TODO: address(0)` | 25 hours |
+| rETH | RETHPriceFeed | ETH-USD + RETH-ETH + Exchange Rate | `TODO: address(0)` | 25 hours |
+| SNT | SNTPriceFeed | SNT-USD | `TODO: address(0)` | 25 hours |
+| LINEA | LINEAPriceFeed | LINEA-USD | `TODO: address(0)` | 25 hours |
+| sGUSD | SGUSDPriceFeed | sGUSD-USD | `TODO: address(0)` | 25 hours |
+
+## Collateral Parameters (from spec)
+
+| Token | Initial Debt Limit | MCR | SCR | CCR | Liq Penalty |
+|-------|-------------------|-----|-----|-----|-------------|
+| ETH | $100,000,000 | 110% | 110% | 150% | 5% |
+| wstETH | $100,000,000 | 110% | 110% | 160% | 5% |
+| rETH | $100,000,000 | 110% | 110% | 160% | 5% |
+| SNT | $2,000,000 | 160% | 160% | 185% | 5% |
+| LINEA | $2,000,000 | TBD | TBD | TBD | 5% |
+| sGUSD | $5,000,000 | 110% | 110% | 125% | 5% |
+
+## Notes
+
+1. **Staleness threshold**: All feeds use 25 hours (90000 seconds) as the staleness threshold
+2. **SNT**: Status Network Token - may need a custom oracle or use Chainlink if available
+3. **LINEA**: Linea token - oracle TBD
+4. **sGUSD**: Staked GUSD - likely pegged close to $1, may use GUSD oracle
+
+## Deployment Steps
+
+1. Obtain oracle addresses for each token
+2. Update the deployment script with the addresses
+3. Deploy price feeds with correct staleness thresholds
+4. Verify all oracles are returning valid prices before deployment

--- a/contracts/src/PriceFeeds/SGUSDPriceFeed.sol
+++ b/contracts/src/PriceFeeds/SGUSDPriceFeed.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "./MainnetPriceFeedBase.sol";
+
+/**
+ * @title SGUSDPriceFeed
+ * @notice Price feed for sGUSD (staked GUSD)
+ * @dev Uses a single sGUSD-USD oracle. sGUSD is expected to track $1 closely.
+ */
+contract SGUSDPriceFeed is MainnetPriceFeedBase {
+    // TODO: Set the actual sGUSD-USD oracle address on deployment
+    // address constant SGUSD_USD_ORACLE = address(0);
+    
+    // sGUSD is a stablecoin, expected to be ~$1
+    // May use a fixed price or GUSD oracle as fallback
+
+    constructor(
+        address _sgusdUsdOracleAddress,
+        uint256 _sgusdUsdStalenessThreshold,
+        address _borrowerOperationsAddress
+    )
+        MainnetPriceFeedBase(_sgusdUsdOracleAddress, _sgusdUsdStalenessThreshold, _borrowerOperationsAddress)
+    {
+        _fetchPricePrimary();
+
+        // Check the oracle didn't already fail
+        assert(priceSource == PriceSource.primary);
+    }
+
+    function fetchPrice() public returns (uint256, bool) {
+        // If branch is live and the primary oracle setup has been working, try to use it
+        if (priceSource == PriceSource.primary) return _fetchPricePrimary();
+
+        // Otherwise if branch is shut down and already using the lastGoodPrice, continue with it
+        assert(priceSource == PriceSource.lastGoodPrice);
+        return (lastGoodPrice, false);
+    }
+
+    function fetchRedemptionPrice() external returns (uint256, bool) {
+        // Use same price for redemption as all other ops
+        return fetchPrice();
+    }
+
+    function _fetchPricePrimary() internal returns (uint256, bool) {
+        assert(priceSource == PriceSource.primary);
+        (uint256 sgusdUsdPrice, bool sgusdUsdOracleDown) = _getOracleAnswer(ethUsdOracle);
+
+        // If the sGUSD-USD oracle response was invalid, return the last good price
+        if (sgusdUsdOracleDown) return (_shutDownAndSwitchToLastGoodPrice(address(ethUsdOracle.aggregator)), true);
+
+        lastGoodPrice = sgusdUsdPrice;
+        return (sgusdUsdPrice, false);
+    }
+}

--- a/contracts/src/PriceFeeds/SNTPriceFeed.sol
+++ b/contracts/src/PriceFeeds/SNTPriceFeed.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "./MainnetPriceFeedBase.sol";
+
+/**
+ * @title SNTPriceFeed
+ * @notice Price feed for Status Network Token (SNT)
+ * @dev Uses a single SNT-USD oracle
+ */
+contract SNTPriceFeed is MainnetPriceFeedBase {
+    // TODO: Set the actual SNT-USD oracle address on deployment
+    // address constant SNT_USD_ORACLE = address(0);
+
+    constructor(
+        address _sntUsdOracleAddress,
+        uint256 _sntUsdStalenessThreshold,
+        address _borrowerOperationsAddress
+    )
+        MainnetPriceFeedBase(_sntUsdOracleAddress, _sntUsdStalenessThreshold, _borrowerOperationsAddress)
+    {
+        _fetchPricePrimary();
+
+        // Check the oracle didn't already fail
+        assert(priceSource == PriceSource.primary);
+    }
+
+    function fetchPrice() public returns (uint256, bool) {
+        // If branch is live and the primary oracle setup has been working, try to use it
+        if (priceSource == PriceSource.primary) return _fetchPricePrimary();
+
+        // Otherwise if branch is shut down and already using the lastGoodPrice, continue with it
+        assert(priceSource == PriceSource.lastGoodPrice);
+        return (lastGoodPrice, false);
+    }
+
+    function fetchRedemptionPrice() external returns (uint256, bool) {
+        // Use same price for redemption as all other ops
+        return fetchPrice();
+    }
+
+    function _fetchPricePrimary() internal returns (uint256, bool) {
+        assert(priceSource == PriceSource.primary);
+        (uint256 sntUsdPrice, bool sntUsdOracleDown) = _getOracleAnswer(ethUsdOracle);
+
+        // If the SNT-USD oracle response was invalid, return the last good price
+        if (sntUsdOracleDown) return (_shutDownAndSwitchToLastGoodPrice(address(ethUsdOracle.aggregator)), true);
+
+        lastGoodPrice = sntUsdPrice;
+        return (sntUsdPrice, false);
+    }
+}


### PR DESCRIPTION
## Overview

Updates the deployment script to support all 6 collateral types with proper parameters from the spec.

## Collaterals (6 total)

| # | Token | Debt Limit | MCR | SCR | CCR | Liq Penalty |
|---|-------|-----------|-----|-----|-----|-------------|
| 0 | ETH | $100M | 110% | 110% | 150% | 5%/10% |
| 1 | wstETH | $100M | 110% | 110% | 160% | 5%/20% |
| 2 | rETH | $100M | 110% | 110% | 160% | 5%/20% |
| 3 | SNT | $2M | 160% | 160% | 185% | 5%/10% |
| 4 | LINEA | $2M | 160% | 160% | 185% | 5%/10% |
| 5 | sGUSD | $5M | 110% | 110% | 125% | 5%/10% |

## Changes

### `DeployLiquity2.s.sol`
- `NUM_BRANCHES`: 3 → 6
- Added `TroveManagerParams` for SNT, LINEA, sGUSD
- Added token/oracle addresses (`address(0)` TODOs)
- Updated staleness thresholds to 25 hours
- Imported new price feeds

### `Constants.sol`
- Added CCR/MCR/SCR constants for new collaterals
- **Fixed**: SETH MCR/SCR 120% → 110% per spec
- Added liquidation penalties for new collaterals
- Added debt limit constants

### New Price Feeds
- `SNTPriceFeed.sol`
- `LINEAPriceFeed.sol`
- `SGUSDPriceFeed.sol`
- `ORACLE_CONFIG.md` documentation

## TODO Before Deployment
- [ ] Fill in token addresses (SNT, LINEA, sGUSD)
- [ ] Fill in oracle addresses
- [ ] Verify oracle staleness thresholds