### PR TITLE
fix: Cyfrin audit findings (L2, L3, I2, I3)

### DIFF
--- a/contracts/script/DeployLiquity2.s.sol
+++ b/contracts/script/DeployLiquity2.s.sol
@@ -116,7 +116,7 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
     // Staleness thresholds
     uint256 ETH_USD_STALENESS_THRESHOLD = 25 hours; // Updated to 25h per spec
     uint256 STETH_USD_STALENESS_THRESHOLD = 25 hours;
-    uint256 RETH_ETH_STALENESS_THRESHOLD = 48 hours;
+    uint256 RETH_ETH_STALENESS_THRESHOLD = 25 hours; // Fixed: was 48h, should match doc (25h)
     uint256 SNT_USD_STALENESS_THRESHOLD = 25 hours;
     uint256 LINEA_USD_STALENESS_THRESHOLD = 25 hours;
     uint256 SGUSD_USD_STALENESS_THRESHOLD = 25 hours;

--- a/contracts/src/NFTMetadata/MetadataNFT.sol
+++ b/contracts/src/NFTMetadata/MetadataNFT.sol
@@ -36,11 +36,11 @@ contract MetadataNFT is IMetadataNFT {
     function uri(TroveData memory _troveData) public view returns (string memory) {
         string memory attr = attributes(_troveData);
         return json.formattedMetadata(
-            string.concat("Liquity V2 - ", IERC20Metadata(_troveData._collToken).name()),
+            string.concat("Firm Money - ", IERC20Metadata(_troveData._collToken).name()),
             string.concat(
-                "Liquity V2 is a collateralized debt platform. Users can lock up ",
+                "Firm Money is a collateralized debt platform. Users can lock up ",
                 IERC20Metadata(_troveData._collToken).symbol(),
-                " to issue stablecoin tokens (BOLD) to their own Ethereum address. The individual collateralized debt positions are called Troves, and are represented as NFTs."
+                " to issue stablecoin tokens (USF) to their own address. The individual collateralized debt positions are called Troves, and are represented as NFTs."
             ),
             renderSVGImage(_troveData),
             attr

--- a/contracts/src/PriceFeeds/ORACLE_CONFIG.md
+++ b/contracts/src/PriceFeeds/ORACLE_CONFIG.md
@@ -27,7 +27,7 @@ All addresses need to be filled in before deployment.
 
 ## Notes
 
-1. **Staleness threshold**: All feeds use 25 hours (90000 seconds) as the staleness threshold
+1. **Staleness threshold**: All feeds use 25 hours (90000 seconds) as the staleness threshold, including rETH-ETH (fixed from 48h)
 2. **SNT**: Status Network Token - may need a custom oracle or use Chainlink if available
 3. **LINEA**: Linea token - oracle TBD
 4. **sGUSD**: Staked GUSD - likely pegged close to $1, may use GUSD oracle

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -375,21 +375,22 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
          *  - Send a fraction of the trove's collateral to the Stability Pool, equal to the fraction of its offset debt
          *
          */
+        // L3 fix: Always award gas compensation from total coll, even when SP is empty
+        collGasCompensation = _getCollGasCompensation(_entireTroveColl);
+        uint256 collAfterGasComp = _entireTroveColl - collGasCompensation;
+
         if (_boldInSPForOffsets > 0) {
             debtToOffset = LiquityMath._min(_entireTroveDebt, _boldInSPForOffsets);
-            collSPPortion = _entireTroveColl * debtToOffset / _entireTroveDebt;
-
-            collGasCompensation = _getCollGasCompensation(collSPPortion);
-            uint256 collToOffset = collSPPortion - collGasCompensation;
+            collSPPortion = collAfterGasComp * debtToOffset / _entireTroveDebt;
 
             (collToSendToSP, collSurplus) =
-                _getCollPenaltyAndSurplus(collToOffset, debtToOffset, LIQUIDATION_PENALTY_SP, _price);
+                _getCollPenaltyAndSurplus(collSPPortion, debtToOffset, LIQUIDATION_PENALTY_SP, _price);
         }
 
         // Redistribution
         debtToRedistribute = _entireTroveDebt - debtToOffset;
         if (debtToRedistribute > 0) {
-            uint256 collRedistributionPortion = _entireTroveColl - collSPPortion;
+            uint256 collRedistributionPortion = collAfterGasComp - collSPPortion;
             if (collRedistributionPortion > 0) {
                 (collToRedistribute, collSurplus) = _getCollPenaltyAndSurplus(
                     collRedistributionPortion + collSurplus, // Coll surplus from offset can be eaten up by red. penalty


### PR DESCRIPTION
## Cyfrin Audit Response

Addresses findings from the Cyfrin security audit (Feb 23-27, 2026).

### Acknowledged (no code change)
- **M1** — Debt-limit enforcement inconsistency: intentional design allowing interest/fee accrual above limit
- **L1** — Deployment script missing new collaterals support: acknowledged
- **L4** — Insufficient liquidator incentive on non-ETH branches: acknowledged (universal 0.1 ETH cap is by design)

### Fixed
| Finding | Severity | Fix |
|---------|----------|-----|
| **L2** — rETH oracle staleness mismatch | Low | Corrected `RETH_ETH_STALENESS_THRESHOLD` from 48h → 25h to match ORACLE_CONFIG.md |
| **L3** — Empty SP removes liquidator incentive | Low | Gas compensation now taken from total collateral *before* SP/redistribution split. Liquidators always get paid. |
| **I2** — rETH staleness config vs docs | Info | Same fix as L2 |
| **I3** — MetadataNFT wrong branding | Info | Updated NFT metadata from "Liquity V2" / "BOLD" → "Firm Money" / "USF" |

### Files Changed
- `contracts/script/DeployLiquity2.s.sol` — staleness threshold fix
- `contracts/src/TroveManager.sol` — liquidator gas compensation fix
- `contracts/src/NFTMetadata/MetadataNFT.sol` — branding fix
- `contracts/src/PriceFeeds/ORACLE_CONFIG.md` — doc update