### PR TITLE
fix(L2/I2): correct rETH-ETH staleness threshold from 48h to 25h

### DIFF
--- a/contracts/script/DeployLiquity2.s.sol
+++ b/contracts/script/DeployLiquity2.s.sol
@@ -116,7 +116,7 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
     // Staleness thresholds
     uint256 ETH_USD_STALENESS_THRESHOLD = 25 hours; // Updated to 25h per spec
     uint256 STETH_USD_STALENESS_THRESHOLD = 25 hours;
-    uint256 RETH_ETH_STALENESS_THRESHOLD = 48 hours;
+    uint256 RETH_ETH_STALENESS_THRESHOLD = 25 hours; // Fixed: was 48h, should be 25h per ORACLE_CONFIG.md
     uint256 SNT_USD_STALENESS_THRESHOLD = 25 hours;
     uint256 LINEA_USD_STALENESS_THRESHOLD = 25 hours;
     uint256 SGUSD_USD_STALENESS_THRESHOLD = 25 hours;

--- a/contracts/src/PriceFeeds/ORACLE_CONFIG.md
+++ b/contracts/src/PriceFeeds/ORACLE_CONFIG.md
@@ -27,7 +27,7 @@ All addresses need to be filled in before deployment.
 
 ## Notes
 
-1. **Staleness threshold**: All feeds use 25 hours (90000 seconds) as the staleness threshold
+1. **Staleness threshold**: All feeds use 25 hours (90000 seconds) as the staleness threshold, including rETH-ETH (fixed from 48h)
 2. **SNT**: Status Network Token - may need a custom oracle or use Chainlink if available
 3. **LINEA**: Linea token - oracle TBD
 4. **sGUSD**: Staked GUSD - likely pegged close to $1, may use GUSD oracle


### PR DESCRIPTION
**Cyfrin Audit: L2 (Low) + I2 (Informational)**

`RETH_ETH_STALENESS_THRESHOLD` was 48 hours but ORACLE_CONFIG.md specifies 25 hours for all feeds. This means the rETH-ETH oracle could serve staler data than intended before triggering fallback.

**Changes:** `contracts/script/DeployLiquity2.s.sol`, `contracts/src/PriceFeeds/ORACLE_CONFIG.md`