### PR TITLE
fix(I3): update MetadataNFT branding from Liquity V2 to Firm Money

### DIFF
--- a/contracts/src/NFTMetadata/MetadataNFT.sol
+++ b/contracts/src/NFTMetadata/MetadataNFT.sol
@@ -36,11 +36,11 @@ contract MetadataNFT is IMetadataNFT {
     function uri(TroveData memory _troveData) public view returns (string memory) {
         string memory attr = attributes(_troveData);
         return json.formattedMetadata(
-            string.concat("Liquity V2 - ", IERC20Metadata(_troveData._collToken).name()),
+            string.concat("Firm Money - ", IERC20Metadata(_troveData._collToken).name()),
             string.concat(
-                "Liquity V2 is a collateralized debt platform. Users can lock up ",
+                "Firm Money is a collateralized debt platform. Users can lock up ",
                 IERC20Metadata(_troveData._collToken).symbol(),
-                " to issue stablecoin tokens (BOLD) to their own Ethereum address. The individual collateralized debt positions are called Troves, and are represented as NFTs."
+                " to issue stablecoin tokens (USF) to their own address. The individual collateralized debt positions are called Troves, and are represented as NFTs."
             ),
             renderSVGImage(_troveData),
             attr


### PR DESCRIPTION
**Cyfrin Audit: I3 (Informational)**

Trove NFT metadata still referenced "Liquity V2" and "BOLD". Updated to "Firm Money" and "USF".

**Changes:** `contracts/src/NFTMetadata/MetadataNFT.sol`